### PR TITLE
CC-34178: Bump `common-beanutils` to fix CVE-2025-48734

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.4</version>
+            <version>1.11.0</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>


### PR DESCRIPTION
This pull request includes a single change to the `pom.xml` file. The change updates the version of the `commons-beanutils` dependency from `1.9.4` to `1.11.0` to ensure compatibility with newer features and security updates.