### PR TITLE
CC-34178: Bump common-beanutils from 1.9.4 to 1.11.0 to fix CVE-2025-48734

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.4</version>
+            <version>1.11.0</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>


### PR DESCRIPTION
This pull request updates the version of a dependency in the `pom.xml` file to address potential compatibility or security concerns.

Dependency update:

* Updated the `commons-beanutils` dependency version from `1.9.4` to `1.11.0` in the `pom.xml` file.