### PR TITLE
CC-35436: Bump ``opencsv`` to ``5.12.0`` to fix ``CVE-2025-48924``

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>4.6</version>
+            <version>5.12.0</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.27.1</version>
+            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.jcustenborder.parsers</groupId>

--- a/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/CsvSchemaGenerator.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/spooldir/CsvSchemaGenerator.java
@@ -18,6 +18,7 @@ package com.github.jcustenborder.kafka.connect.spooldir;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.ICSVParser;
+import com.opencsv.exceptions.CsvValidationException;
 import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,10 +51,19 @@ public class CsvSchemaGenerator extends AbstractSchemaGenerator<SpoolDirCsvSourc
         String[] headers = null;
 
         if (this.config.firstRowAsHeader) {
-          headers = csvReader.readNext();
+          try {
+            headers = csvReader.readNext();
+          } catch (CsvValidationException e) {
+            throw new RuntimeException("Failed during csv validation while reading header row", e);
+          }
         }
 
-        String[] row = csvReader.readNext();
+        String[] row;
+        try {
+          row = csvReader.readNext();
+        } catch (CsvValidationException e) {
+          throw new RuntimeException("Failed during csv validation while reading data row", e);
+        }
 
         if (null == headers) {
           headers = new String[row.length];

--- a/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceConnectorConfigTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/spooldir/SpoolDirCsvSourceConnectorConfigTest.java
@@ -4,6 +4,7 @@ package com.github.jcustenborder.kafka.connect.spooldir;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.ICSVParser;
+import com.opencsv.exceptions.CsvValidationException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -16,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 public class SpoolDirCsvSourceConnectorConfigTest {
 
   @Test
-  public void nullFieldSeparator() throws IOException {
+  public void nullFieldSeparator() throws IOException, CsvValidationException {
     Map<String, String> settings = new HashMap<>();
     settings.put(SpoolDirCsvSourceConnectorConfig.CSV_SEPARATOR_CHAR_CONF, "0");
     settings.put(SpoolDirCsvSourceConnectorConfig.TOPIC_CONF, "test");


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/CC-35436

- Bump opencsv to 5.12.0 to fix CVE-2025-48924
- Add exception handling